### PR TITLE
Add simple art gallery page

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -6,6 +6,7 @@ const navItems = [
   { name: 'National Security', href: '/national-security' },
   { name: 'Cyber Security', href: '/cyber-security' },
   { name: 'Hybrid Warfare', href: '/hybrid-warfare' },
+  { name: 'Art', href: '/art' },
 ];
 
 const currentPath = Astro.url.pathname;

--- a/src/pages/art.astro
+++ b/src/pages/art.astro
@@ -1,0 +1,24 @@
+---
+import Layout from '../layouts/Layout.astro';
+import img1 from '../assets/IMG_0029.jpg';
+import img2 from '../assets/IMG_0044.png';
+import img3 from '../assets/IMG_0045.png';
+import img4 from '../assets/IMG_0046.png';
+import img5 from '../assets/IMG_0047.png';
+import img6 from '../assets/IMG_0048.png';
+
+const images = [img1, img2, img3, img4, img5, img6];
+---
+
+<Layout title="Art Gallery">
+  <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-16">
+    <h1 class="text-3xl font-heading font-bold text-primary-500 dark:text-white mb-8">
+      Art Gallery
+    </h1>
+    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-8">
+      {images.map(img => (
+        <img src={img.src} alt="Artwork" class="rounded-lg shadow-md" />
+      ))}
+    </div>
+  </div>
+</Layout>


### PR DESCRIPTION
## Summary
- create `/art` page with a basic gallery
- link new page from header navigation

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6845a7f5e2548323a6f4d0de07d04a8d