### PR TITLE
Use Hybridsec logo in header and footer

### DIFF
--- a/public/hybridsec-logo.svg
+++ b/public/hybridsec-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 32" fill="none">
+  <text x="0" y="24" font-family="Montserrat, sans-serif" font-size="24" font-weight="700" fill="#0A1128">Hybridsec</text>
+  <style>
+    @media (prefers-color-scheme: dark) { text { fill: #FFF; } }
+  </style>
+</svg>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -35,9 +35,7 @@ const socialIcons = {
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-8">
       <div class="lg:col-span-2">
         <a href="/" class="text-2xl font-heading font-bold text-primary-500 dark:text-white flex items-center space-x-2">
-          <span class="flex items-center justify-center bg-primary-500 dark:bg-white w-8 h-8 rounded-full">
-            <span class="text-white dark:text-primary-500 font-bold">P</span>
-          </span>
+          <img src="/hybridsec-logo.svg" alt="Hybridsec Perspective logo" class="h-8 w-auto" />
           <span>Perspective</span>
         </a>
         <p class="mt-4 text-gray-600 dark:text-gray-300 max-w-md">

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -16,9 +16,7 @@ const currentPath = Astro.url.pathname;
   <div class="container mx-auto px-4 sm:px-6 lg:px-8">
     <div class="flex justify-between items-center py-4">
       <a href="/" class="text-2xl font-heading font-bold text-primary-500 dark:text-white flex items-center space-x-2">
-        <span class="flex items-center justify-center bg-primary-500 dark:bg-white w-8 h-8 rounded-full">
-          <span class="text-white dark:text-primary-500 font-bold">P</span>
-        </span>
+        <img src="/hybridsec-logo.svg" alt="Hybridsec Perspective logo" class="h-8 w-auto" />
         <span>Perspective</span>
       </a>
       


### PR DESCRIPTION
## Summary
- add `hybridsec-logo.svg` brand mark
- replace monogram spans in header and footer with logo image and align sizing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb6bcc38b88323a68ed8659b130630